### PR TITLE
Starts the service after redis

### DIFF
--- a/securedrop-log.service
+++ b/securedrop-log.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=securedrop logging Service
-After=network.target
+After=network.target redis.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Starts the `securedrop-log` service only after the `redis` service is running.

This is something I found while working on https://github.com/freedomofpress/securedrop-workstation/pull/447