### PR TITLE
Use qubesdb-read instead of gethostname

### DIFF
--- a/sd-rsyslog
+++ b/sd-rsyslog
@@ -76,8 +76,7 @@ def onInit():
 
     global process
     if not os.path.exists("/etc/sd-rsyslog.conf"):
-        logging.exception("Please create the configuration file at /etc/sd-rsyslog.conf",
-                          file=sys.stderr)
+        logging.exception("Please create the configuration file at /etc/sd-rsyslog.conf")
         sys.exit(1)
     config = configparser.ConfigParser()
     config.read('/etc/sd-rsyslog.conf')

--- a/sd-rsyslog
+++ b/sd-rsyslog
@@ -76,7 +76,8 @@ def onInit():
 
     global process
     if not os.path.exists("/etc/sd-rsyslog.conf"):
-        print("Please create the configuration file at /etc/sd-rsyslog.conf", file=sys.stderr)
+        logging.exception("Please create the configuration file at /etc/sd-rsyslog.conf",
+                          file=sys.stderr)
         sys.exit(1)
     config = configparser.ConfigParser()
     config.read('/etc/sd-rsyslog.conf')
@@ -91,14 +92,14 @@ def onInit():
                                         stdout=PIPE, stderr=PIPE)
             vm_name_output, vm_name_error = get_vm_name_process.communicate()
             if vm_name_error != b"":
-                print("Error obtaining VM name via qubesdb-read:")
-                print(vm_name_error.decode("utf-8").strip())
+                logging.exception("Error obtaining VM name via qubesdb-read:")
+                logging.exception(vm_name_error.decode("utf-8").strip())
                 sys.exit(1)
             localvmname = vm_name_output.decode("utf-8").strip()
         except FileNotFoundError:  # not on Qubes?
-            print("Could not run qubesdb-read command to obtain VM name.")
-            print("Note that sd-rsyslog must be run on Qubes OS if no")
-            print("localvm name is specified in the configuration.")
+            logging.exception("Could not run qubesdb-read command to obtain VM name.")
+            logging.exception("Note that sd-rsyslog must be run on Qubes OS if no "
+                              "localvm name is specified in the configuration.")
             sys.exit(1)
 
     process = Popen(

--- a/sd-rsyslog
+++ b/sd-rsyslog
@@ -30,10 +30,10 @@ import os
 import logging
 import configparser
 from subprocess import Popen, PIPE
-from socket import gethostname
 
 # Global definitions specific to your plugin
 process = None
+
 
 class RecoverableError(Exception):
     """An error that has caused the processing of the current message to
@@ -74,7 +74,6 @@ def onInit():
     # emitted you must set 'level' to logging.DEBUG above.)
     logging.debug("onInit called")
 
-
     global process
     if not os.path.exists("/etc/sd-rsyslog.conf"):
         print("Please create the configuration file at /etc/sd-rsyslog.conf", file=sys.stderr)
@@ -82,7 +81,26 @@ def onInit():
     config = configparser.ConfigParser()
     config.read('/etc/sd-rsyslog.conf')
     logvmname = config['sd-rsyslog']['remotevm']
-    localvmname = config['sd-rsyslog'].get('localvm', gethostname())
+    localvmname = config['sd-rsyslog'].get('localvm', None)
+
+    # If no localvm name is specified, it must be supplied by Qubes OS. If this
+    # fails, we exit, to avoid falsely identified logs.
+    if localvmname is None:
+        try:
+            get_vm_name_process = Popen(["/usr/bin/qubesdb-read", "/name"],
+                                        stdout=PIPE, stderr=PIPE)
+            vm_name_output, vm_name_error = get_vm_name_process.communicate()
+            if vm_name_error != b"":
+                print("Error obtaining VM name via qubesdb-read:")
+                print(vm_name_error.decode("utf-8").strip())
+                sys.exit(1)
+            localvmname = vm_name_output.decode("utf-8").strip()
+        except FileNotFoundError:  # not on Qubes?
+            print("Could not run qubesdb-read command to obtain VM name.")
+            print("Note that sd-rsyslog must be run on Qubes OS if no")
+            print("localvm name is specified in the configuration.")
+            sys.exit(1)
+
     process = Popen(
             ["/usr/lib/qubes/qrexec-client-vm", logvmname, "securedrop.Log"],
             stdin=PIPE,
@@ -144,7 +162,7 @@ via stdout. In most cases, modifying this code should not be necessary.
 """
 try:
     onInit()
-except Exception as e:
+except Exception:
     # If an error occurs during initialization, log it and terminate. The
     # 'omprog' action will eventually restart the program.
     logging.exception("Initialization error, exiting program")
@@ -191,4 +209,3 @@ if endedWithError:
     sys.exit(1)
 else:
     sys.exit(0)
-


### PR DESCRIPTION
## Description

Switches to the use of `qubesdb-read` to identify the source VM. This prevents misidentification of Whonix VMs, which always use `host` as the hostname, and should generally be a bit more qubesy.

Preserves the `localvm` option mainly for testing outside Qubes; if not set, `sd-rsyslog` will fail on non-Qubes systems.

Fixes https://github.com/freedomofpress/securedrop-workstation/issues/583

## Status

Ready for review.

## Test plan

### Prerequisites
- A working, up-to-date SecureDrop Workstation development or staging install.
- [ ] Observe that the file `/etc/rsyslog.d/sdlog.conf` exists on `whonix-gw-15`. If not, abort (we'll have to debug why).

### Instructions
1. Build a package from this branch by following the standard `securedrop-debian-packaging` procedure. You don't have to bump version numbers as long as you don't run the updater during this test. In a nutshell (assuming build prereqs are installed in your dev VM), run `python3 setup.py sdist` in the `securedrop-log` checkout and then `PKG_VERSION=0.1.1 PKG_PATH=/path/to/package.tgz make securedrop-log` in the `securedrop-debian-packaging` checkout.

2. Install the package in `sd-log-buster-template`, `sd-app-buster-template`, and `whonix-gw-15` by copying it there and then running  `dpkg -i /path/to/package.deb`. I took the intermediate step of copying it from my dev VM to `dom0` to avoid updating RPC policies. <br><br>Why these three TemplateVMs? Updating the package in `sd-log-buster-template` ensures that we've not broken the logging package itself. Updating the package in `whonix-gw-15` ensures we're actually fixing  https://github.com/freedomofpress/securedrop-workstation/issues/583. Updating the package in `sd-app-buster-template` ensures that we've not broken logging from other AppVMs.

3. Boot up `sd-whonix` and remove the entire block `### BEGIN securedrop-workstation ###...### END securedrop-workstation ###` from `/rw/config/rc.local`. <br><br>Why this edit? This ensures that the `localvm` parameter is no longer set late in the boot process (too late, which causes the sorting of early logs into `host`), and we instead rely on autodetection of the VM name using `qubesdb-read`, with the version of `sd-rsyslog` that ships in this package. The related Salt change https://github.com/freedomofpress/securedrop-workstation/pull/618/commits/ce3a921c849a2b57b398816ca17747b9cd593ae7 will do this automatically.

4. Shut down all running SD Workstation VMs except `sd-log` (including templates), then remove or archive all log subdirectories in `~/QubesIncomingLogs` on `sd-log`. We want a clean slate for verifying log behavior.

5. Reboot the Qubes machine (we want to verify a production-like VM boot sequence). After reboot, do **not** run the updater to ensure your package change is presreved.

6. After reboot, examine the contents of `~/QubesIncomingLogs` of `sd-log`. 

- [ ] Observe that there is no `host` directory.

7. Run a command like `logger foo` in `sd-app` and `sd-whonix`.

- [ ] Observe that the log lines are added in the correct subdirectories of `~/QubesIncomingLogs`.

8. For good measure, run `make test` in your `dom0` SecureDrop Workstation checkout directory. The `sd-log` test should no longer fail, and there should be no new test failures.

9. In `dom0`, run `make clean` to remove your SecureDrop Workstation setup completely, or run `sdw-admin --apply` and the updater to restore the previous state.

