### PR TITLE
Adds upgrade-pip makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ safety: ## Runs `safety check` to check python dependencies for vulnerabilities
 update-pip-requirements: ## Updates all Python requirements files via pip-compile.
 	pip-compile --generate-hashes --output-file requirements.txt requirements.in
 
+.PHONY: upgrade-pip
+upgrade-pip: ## Upgrade one single package via pip-compile
+	pip-compile --generate-hashes --upgrade-package $(PACKAGE) --output-file requirements.txt requirements.in
 
 # Explaination of the below shell command should it ever break.
 # 1. Set the field separator to ": ##" and any make targets that might appear between : and ##

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@
 
 This is a Python module and qrexec service for logging in Qubes for [SecureDrop](https://securedrop.org).
 
+## How to upgrade the dependencies?
+
+To upgrade one single Python dependency, say `redis`, run the following:
+
+```bash
+PACKAGE=redis make upgrade-pip
+```
+
 ## How to use/try this?
 
 In our example, we will use a vm named *logging* for storing logs, and we will use


### PR DESCRIPTION
One can upgrade a dependency via:
`PACKAGE=packagename make upgrade-pip`

## How to test?

- [ ] Add a new dependency to the `requirements.in`
- [ ] Run `PACKAGE=packagename make upgrade-pip`