### PR TITLE
Explicitly set packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,10 @@ setuptools.setup(
     license="GPLv3+",
     install_requires=[],
     python_requires=">=3.5",
+    packages=setuptools.find_packages(exclude=["docs", "tests"]),
+    package_data={
+        'securedrop_log': ['VERSION'],
+    },
     url="https://github.com/freedomofpress/securedrop-log",
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
This is generally a good practice instead of relying on autodiscovery,
plus it's what the other securedrop- packages do. Also it fixes a weird
bug with reprotest, in which it can't determine the correct package.

Fixes https://github.com/freedomofpress/securedrop-debian-packaging/issues/298.

## Test plan
* [x] Manually run reprotest, something like `PKG_GITREF=packages pytest -vvs tests/test_reproducible_debian_packages.py -k securedrop-log` in the securedrop-debian-packages repo, verify it no longer fails.
* [ ] Verify the debdiff from the stable 0.1.2 and a package built from this branch looks good: https://gist.github.com/legoktm/6f732edda69e86c05bcbf91da06cec62