### PR TITLE
Build Debian package from repository instead of tarball

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,21 +25,13 @@ common-steps:
         # previous run step), else return 0.
         git diff --quiet
 
-  - &make_source_tarball
-    run:
-      name: Tag and make source tarball
-      command: |
-        cd ~/project
-        ./update_version.sh 1000.0  # Dummy version number, doesn't matter what we put here
-        python3 setup.py sdist
-
   - &build_debian_package
     run:
       name: Build debian package
       command: |
         cd ~/packaging/securedrop-debian-packaging
         export PKG_VERSION=1000.0
-        export PKG_PATH=/home/circleci/project/dist/securedrop-log-$PKG_VERSION.tar.gz
+        export PKG_PATH=~/project/
         make securedrop-log
 
 version: 2
@@ -61,7 +53,6 @@ jobs:
       - *removevirtualenv
       - *install_packaging_dependencies
       - *verify_requirements
-      - *make_source_tarball
       - *build_debian_package
 
 workflows:


### PR DESCRIPTION
This works around a difference of behavior of the building tools between tarball and directory targets, that causes tarball builds to rely on outdated tooling.

See https://github.com/freedomofpress/securedrop-client/pull/1499 and https://github.com/freedomofpress/securedrop-debian-packaging/pull/332